### PR TITLE
Support a user-configurable test runner executable

### DIFF
--- a/bin/taper.js
+++ b/bin/taper.js
@@ -9,6 +9,7 @@ prog
   .usage('[options] <path ...>')
   .option('--no-color', 'Run without colorization')
   .option('--timeout [ms]' , 'Individual test file timeout (ms; default=10000)', 10000)
+  .option('--runner [executable]', 'Name of alternative executable to run test-files with')
   .parse(process.argv);
 
 
@@ -22,7 +23,10 @@ var path = require("path");
 var Runner = require("../lib/taper");
 var TapProducer = require("tap").Producer;
 
-var options = { color: prog.color, timeout: +prog.timeout || 10000 };
+var options = {
+  color: prog.color,
+  timeout: +prog.timeout || 10000,
+  runner: prog.runner };
 var r = new Runner(prog.args, options);
 var colorize = prog.color;
 

--- a/bin/taper.js
+++ b/bin/taper.js
@@ -10,8 +10,9 @@ var VERSION = require('../package.json').version;
 var args = minimist(process.argv, {
   default: { color: true, timeout: 10000 }
 , boolean: ['help', 'version']
-, string: ['runner']
-, alias: { h: 'help', V: 'version', color: 'colour'}
+, string: ['runner', 'runner-param']
+, alias: { h: 'help', V: 'version', P: 'runner-param', color: 'colour'}
+, '--': true
 });
 var argv = args._;
 
@@ -30,14 +31,20 @@ if (args.help || argv.length <= 2) {
   process.exit(1);
 }
 
+if (typeof args['runner-param'] === 'string') {
+  args['runner-param'] = [args['runner-param']];
+}
+
 var Runner = require("../lib/taper");
 var TapProducer = require("tap").Producer;
 
 var options = {
   color: args.color,
   timeout: +args.timeout,
-  runner: args.runner };
-var r = new Runner(argv[2], options);
+  runner: args.runner,
+  params: (args['runner-param'] || []).concat(args['--']) };
+
+var r = new Runner(argv.slice(2), options);
 var colorize = args.color;
 
 r.on("file", function (file, results, details) {

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -7,5 +7,13 @@
     -V, --version          Print the version number (and exit)
     --no-color             Disable all colorization
     --timeout [ms]         Individual test file timeout (in ms; default=10000)
-    --runner [executable]  Name of alternative executable to run test-files with
+
+    --runner [executable]
+        Name of alternative executable to run test-files with
+
+    -P, --runner-param [parameter]
+        An individual parameter to be passed, verbatim, to the test-runner.
+
+        Any arguments following a raw '--' will also be passed to the runner,
+        without any sort of parsing or recognition by taper.
 

--- a/doc/help.txt
+++ b/doc/help.txt
@@ -1,0 +1,11 @@
+
+  Usage: $0 [options] <path ...>
+
+  Options:
+
+    -h, --help             Show usage information (and exit)
+    -V, --version          Print the version number (and exit)
+    --no-color             Disable all colorization
+    --timeout [ms]         Individual test file timeout (in ms; default=10000)
+    --runner [executable]  Name of alternative executable to run test-files with
+

--- a/lib/taper.js
+++ b/lib/taper.js
@@ -23,6 +23,7 @@ function Runner (dir, options, cb) {
   this.colorize = options.color;
   this.timeout = options.timeout;
   this.runner = options.runner;
+  this.params = options.params;
 
   if (dir) this.run(dir, cb);
 }
@@ -73,21 +74,21 @@ Runner.prototype.runFiles = function (files, dir, cb) {
           return cb()
         }
 
-        var cmd = f
-          , args = []
+        var command = f
+          , params = self.params.slice()
 
         if (typeof self.runner !== 'undefined') {
-          cmd = self.runner
-          args = [fileName]
+          command = self.runner
+          params.push(fileName)
         } else if (path.extname(f) === ".js") {
-          cmd = "node"
-          args = [fileName]
+          command = "node"
+          params.push(fileName)
         } else if (path.extname(f) === ".coffee") {
-          cmd = "coffee"
-          args = [fileName]
+          command = "coffee"
+          params.push(fileName)
         } else if (path.extname(f) === ".tap") {
-          cmd = "node"
-          args = [path.join(__dirname, '..', 'bin', 'cat.js'), fileName]
+          command = "node"
+          params = [path.join(__dirname, '..', 'bin', 'cat.js'), fileName]
         }
         if (st.isDirectory()) {
           return self.runDir(f, cb)
@@ -97,7 +98,7 @@ Runner.prototype.runFiles = function (files, dir, cb) {
         for (var i in process.env) env[i] = process.env[i]
         env.TAP = 1
 
-        var cp = child_process.spawn(cmd, args, { env: env, cwd: relDir })
+        var cp = child_process.spawn(command, params, { env: env, cwd: relDir })
           , out = ""
           , fullOutAndErr = ""  //used for combined stdout (tap and other) + stderr, used for failed
           , nonTapOutAndErr = "" //filtered version of stdout + stderr, used for success
@@ -202,7 +203,7 @@ Runner.prototype.runFiles = function (files, dir, cb) {
               line: 0
             });
           }
-          res.command = [cmd].concat(args).map(JSON.stringify).join(" ")
+          res.command = [command].concat(params).map(JSON.stringify).join(" ")
           self.emit("result", res)
           self.emit("file", f, res, tc.results)
           self.write(res)

--- a/lib/taper.js
+++ b/lib/taper.js
@@ -22,6 +22,7 @@ function Runner (dir, options, cb) {
   Runner.super.call(this, diag);
   this.colorize = options.color;
   this.timeout = options.timeout;
+  this.runner = options.runner;
 
   if (dir) this.run(dir, cb);
 }
@@ -75,7 +76,10 @@ Runner.prototype.runFiles = function (files, dir, cb) {
         var cmd = f
           , args = []
 
-        if (path.extname(f) === ".js") {
+        if (typeof self.runner !== 'undefined') {
+          cmd = self.runner
+          args = [fileName]
+        } else if (path.extname(f) === ".js") {
           cmd = "node"
           args = [fileName]
         } else if (path.extname(f) === ".coffee") {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     },
     "dependencies" : {
         "cli-color" : "~0.1.4",
-        "commander" : "~0.5.0",
+        "minimist"  : "~1.1.0",
         "inherits"  : "~1.0.0",
         "slide"     : "~1.1.3",
         "split"     : "~0.3.2",


### PR DESCRIPTION
Part of the point of the TAP, is to allow different TAP-producing back-ends to participate in the testing of a system. I'm using `taper` as a CLI TAP harness, instead of as a testing library, in itself. However, not everything I'm testing is pure JavaScript; there's other elements of my codebase that are tested with their own test-runners, which produce TAP.

I briefly considered patching `taper` to take TAP on `stdin`; but decided that a huge part of the point of this for me, was the handling of entire directories (i.e. multiple ‘test suites.’) So, instead, I modified `taper` to dispatch the test-files to a different executable at the request of the user.

---

(In the process of fixing this, I had to revert an earlier switch in this codebase from [optimist](https://www.npmjs.com/package/optimist) to [commander](http://npmjs.com/package/commander). I'm not sure the reasons for that switch, so I can't be sure this reversion isn't causing some damage you don't wish; let me know if the usage of [minimist](https://npmjs.com/package/minimist) (the replacement for the since-deprecated optimist) is a complete deal-breaker for you.)
